### PR TITLE
docs: fill in package description

### DIFF
--- a/ember-route-template/package.json
+++ b/ember-route-template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-route-template",
   "version": "1.0.1",
-  "description": "The default blueprint for Embroider v2 addons.",
+  "description": "Provides an adapter for using <template> tags and components as route templates",
   "keywords": [
     "ember-addon"
   ],


### PR DESCRIPTION
So this description really confused me for a bit 😅 

<img width="662" alt="Screenshot 2023-11-04 at 11 33 22" src="https://github.com/discourse/ember-route-template/assets/10243652/867b68e1-ec46-4e0e-ac00-3490653b72db">

Took it over from the main README. It would also be nice to set it as repo description, but I can't PR that.